### PR TITLE
feat: add more models released on october 24, 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import (
 func main() {
 	client := yandexgpt.NewYandexGPTClientWithAPIKey("apiKey")
 	request := yandexgpt.YandexGPTRequest{
-		ModelURI: yandexgpt.MakeModelURI("catalogID", yandexgpt.YandexGPTModelLite),
+		ModelURI: yandexgpt.MakeModelURI("catalogID", yandexgpt.YandexGPT3ModelLite),
 		CompletionOptions: yandexgpt.YandexGPTCompletionOptions{
 			Stream:      false,
 			Temperature: 0.7,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import (
 func main() {
 	client := yandexgpt.NewYandexGPTClientWithAPIKey("apiKey")
 	request := yandexgpt.YandexGPTRequest{
-		ModelURI: yandexgpt.MakeModelURI("catalogID", yandexgpt.YandexGPT3ModelLite),
+		ModelURI: yandexgpt.MakeModelURI("catalogID", yandexgpt.YandexGPTModelLite),
 		CompletionOptions: yandexgpt.YandexGPTCompletionOptions{
 			Stream:      false,
 			Temperature: 0.7,

--- a/models.go
+++ b/models.go
@@ -2,10 +2,12 @@ package yandexgpt
 
 import "fmt"
 
-// TODO: add other models
 var (
-	YandexGPTModel     = yandexGPTModel{modelName: "yandexgpt"}
-	YandexGPTModelLite = yandexGPTModel{modelName: "yandexgpt-lite"}
+	YandexGPT3Model     = yandexGPTModel{modelName: "yandexgpt"}
+	YandexGPT3ModelLite = yandexGPTModel{modelName: "yandexgpt-lite"}
+	YandexGPT4Model     = yandexGPTModel{modelName: "yandexgpt/rc"}
+	YandexGPT4ModelLite = yandexGPTModel{modelName: "yandexgpt-lite/rc"}
+	YandexGPT4Model32k  = yandexGPTModel{modelName: "yandexgpt-32k/rc"}
 )
 
 type yandexGPTModel struct {

--- a/models.go
+++ b/models.go
@@ -3,11 +3,16 @@ package yandexgpt
 import "fmt"
 
 var (
-	YandexGPT3Model     = yandexGPTModel{modelName: "yandexgpt"}
-	YandexGPT3ModelLite = yandexGPTModel{modelName: "yandexgpt-lite"}
-	YandexGPT4Model     = yandexGPTModel{modelName: "yandexgpt/rc"}
+	// Yandex GPT Pro 3rd generation
+	YandexGPTModel = yandexGPTModel{modelName: "yandexgpt"}
+	// Yandex GPT Lite 3rd generation
+	YandexGPTModelLite = yandexGPTModel{modelName: "yandexgpt-lite"}
+	// Yandex GPT Pro 4th generation
+	YandexGPT4Model = yandexGPTModel{modelName: "yandexgpt/rc"}
+	// Yandex GPT Lite 4th generation
 	YandexGPT4ModelLite = yandexGPTModel{modelName: "yandexgpt-lite/rc"}
-	YandexGPT4Model32k  = yandexGPTModel{modelName: "yandexgpt-32k/rc"}
+	// Yandex GPT Pro 32k 4th generation
+	YandexGPT4Model32k = yandexGPTModel{modelName: "yandexgpt-32k/rc"}
 )
 
 type yandexGPTModel struct {


### PR DESCRIPTION
Changes:
- Rename YandexGPT Gen3 Lite to `YandexGPT3ModelLite`
- Rename YandexGPT Gen3 Pro to `YandexGPT3Model`
- Added YandexGPT Gen4 Pro
- Added YandexGPT Gen4 Pro 32k
- Added YandexGPT Gen4 Lite