### PR TITLE
fix: downgraded Go version to 1.21

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.21
       - uses: golangci/golangci-lint-action@v3
   release:
     name: Release
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.21
       - uses: go-semantic-release/action@v1
         with:
           hooks: goreleaser

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library provides unofficial Go client for [YandexGPT API](https://cloud.yan
 ```
 go get github.com/sheeiavellie/go-yandexgpt@latest
 ```
-Currently, go-yandexgpt requires Go version 1.22 or greater.
+Currently, go-yandexgpt requires Go version 1.21 or greater.
 
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sheeiavellie/go-yandexgpt
 
-go 1.22.0
+go 1.21.0


### PR DESCRIPTION
Предлагаю понизить версию Go до 1.21. Тестов в приложении нет, проверил локально через внедрение своего форка в соей проект через replace – работает. 